### PR TITLE
correct conversion between ts file and las file

### DIFF
--- a/apps/ts2las.cpp
+++ b/apps/ts2las.cpp
@@ -102,7 +102,7 @@ liblas::Header CreateHeader(ScanHdr* hdr, bool verbose)
 
     double scale = 1.0/(double)hdr->Units;
     header.SetScale(scale, scale, scale);
-    header.SetOffset(hdr->OrgX*scale, hdr->OrgY*scale, hdr->OrgZ*scale);
+    header.SetOffset(-hdr->OrgX*scale, -hdr->OrgY*scale, -hdr->OrgZ*scale);
     header.SetPointRecordsCount(hdr->PntCnt);
     
     if (verbose)


### PR DESCRIPTION
The conversion formula between terrasolid bin file and Asprs las file seems to be wrong. 
## some math

Current formula use :  XOffset_las =  **+** XOffset_ts/XScale_ts  when  I think it should be  XOffset_las= **-** XOffset_ts/XScale_ts .
-  From terrascan manual (p 305) the formula to obtain ground coordinate from scale offset and file coordinate is :
  
  >  X = (Pnt.X - Hdr.OrgX) / (double) Hdr.Units   
-  From las specification (las 1.3) the formula between ground and las file coordinate is : 
  
  > Xcoordinate = (Xrecord \* Xscale) + Xoffset  
-  So the formula lead to  :
  1.  X_ground = (X_ts - XOffset_ts) /XScale_ts  
       X_ground= (X_las \* XScale_las) + XOffset_las
  2.  (X_las \* XScale_las) + XOffset_las = X_ground = (X_ts - XOffset_ts) /XScale_ts 
      X_las \* XScale_las + XOffset_las = X_ts  /XScale_ts- XOffset_ts /XScale_ts 
  3.  **XScale_las = 1/XScale_ts**  
       **XOffset_las = -XOffset_ts/XScale_ts**
## tests

I've made some test with writing my own terrasolid bin file with a non-null offset. They are well read and postioning when open with terrasolid but if I use ts2las and try with terrasolid to open the corresponding las file it's appear to have wrong coordinate with error equal to 2*Coord_Offset. 
