### PR TITLE
Fix 'seperator' typo, replace with 'separator'.

### DIFF
--- a/apps/las2txt.c
+++ b/apps/las2txt.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
             }
             else
             {
-                fprintf(stderr, "ERROR: unknown seperator '%s'\n",argv[i]);
+                fprintf(stderr, "ERROR: unknown separator '%s'\n",argv[i]);
                 usage();
                 exit(1);
             }


### PR DESCRIPTION
Minor typo fix.
