### PR TITLE
Fix incorrect usage of ctypes' find_library.

### DIFF
--- a/python/liblas/core.py
+++ b/python/liblas/core.py
@@ -152,8 +152,8 @@ elif os.name == 'posix':
         lib_name = 'liblas_c.dylib'
         free = ctypes.CDLL(find_library('libc')).free
     else:
-        lib_name = 'liblas_c.so'
-        free = ctypes.CDLL(find_library('libc.so.6')).free
+        lib_name = 'liblas_c.so.3'
+        free = ctypes.CDLL(find_library('c')).free
     las = ctypes.CDLL(lib_name)
 else:
     raise LASException('Unsupported OS "%s"' % os.name)


### PR DESCRIPTION
The Debian libLAS package has carried this patch for quite a while now, but it was never forwarded by the author for reasons unknown to me.

As discussed in the related issues in the Debian Bug Tracker ([Debian Bug #595603](https://bugs.debian.org/595603) & [Debian Bug #595608](https://bugs.debian.org/595608)), the lib_name variable should use the library filename and not the .so symlink, and instead of searching for the libc.so.6 library it should just search for the 'c' library.

This patch and the accomodate typo patch reported in (#49) are the only patches applied to the Debian package for libLAS 1.8 now.
