### PR TITLE
Fixed bug with dereferencing an empty vector

### DIFF
--- a/src/detail/reader/header.cpp
+++ b/src/detail/reader/header.cpp
@@ -370,9 +370,11 @@ void Header::ReadVLRs()
         uint16_t length = vlrh.recordLengthAfterHeader;
 
         std::vector<uint8_t> data(length);
-
-        read_n(data.front(), m_ifs, length);
-         
+        if (length > 0)
+        {
+            read_n(data.front(), m_ifs, length);
+        }
+        
         VariableRecord vlr;
         vlr.SetReserved(vlrh.reserved);
         vlr.SetUserId(std::string(vlrh.userId, VariableRecord::eUserIdSize));


### PR DESCRIPTION
Was working with some data where one of VLR groups was empty, which caused a crash dereferencing the resultant empty vector. So, I added a guard for this case and everything appears to be functioning again.

Let me know if you need further tweaks to this PR.

Will