### PR TITLE
Issue #76: las2las tries to reproject header bounds without setting coordinates.

### DIFF
--- a/apps/laskernel.cpp
+++ b/apps/laskernel.cpp
@@ -1323,7 +1323,11 @@ std::vector<liblas::TransformPtr> GetTransforms(po::variables_map vm, bool verbo
         liblas::ReprojectionTransform trans(in_ref, out_ref);
     
         liblas::Point minimum(&header);
+        minimum.SetCoordinates(b.minx(), b.miny(), b.minz());
+
         liblas::Point maximum(&header);
+        maximum.SetCoordinates(b.maxx(), b.maxy(), b.maxz());
+        
         trans.transform(minimum);
         trans.transform(maximum);
         b = liblas::Bounds<double>(minimum, maximum);


### PR DESCRIPTION
When attempting to transform a las file that is very definitely within the bounds of both UTM12 and both grid shift files, the following error occurs.

    $ las2las --a_srs EPSG:26912+5713 --t_srs EPSG:26912+6647 test.las test2.las
    pj_open_lib(HT2_0.gtx): call fopen(/usr/local/Cellar/proj/4.9.2/share/proj/HT2_0.gtx) - succeeded
    
    GTX 2820x1290: LL=(-141.983333,41.0166667) UR=(-48.0166667,83.9833333)
    pj_apply_vgridshift(): failed to find a grid shift table for
                       location (-115.4887439dW,0.0000000dN)
    tried: HT2_0.gtx
    ERROR 1: point not within available datum shift grids
    error: Could not project point for ReprojectionTransform::point not within available datum shift grids0

This error seems to originate in laskernel.cpp at 1324, where it tries to reproject the bounds of the header. However, it doesn't set the coordinates on the min/max points, first, and tries to reproject from 0.0, 0.0. This patch is a simple fix for that, and seems to resolve the issue.
[laskernel.cpp.txt](https://github.com/libLAS/libLAS/files/70008/laskernel.cpp.txt)
