### PR TITLE
Fix 'parameters' & 'specified' typos.

### DIFF
--- a/apps/las2ogr.cpp
+++ b/apps/las2ogr.cpp
@@ -279,7 +279,7 @@ int main(int argc, char* argv[])
 
             if (in_file.empty() || out_file.empty() || out_frmt.empty())
             {
-                throw std::runtime_error("missing input paremeters");
+                throw std::runtime_error("missing input parameters");
             }
         }
 

--- a/apps/ts2las.cpp
+++ b/apps/ts2las.cpp
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
     
     if (input.empty())
     {
-        std::cerr << "No input TerraSolid .bin file was specfied!" << std::endl;
+        std::cerr << "No input TerraSolid .bin file was specified!" << std::endl;
         OutputHelp(std::cout, options);
         return 1;
     }


### PR DESCRIPTION
The lintian QA tool reported these spelling errors for the recent rebuild of the libLAS 1.8.0 Debian package with GDAL 1.11.4 and 2.0.2.
