### PR TITLE
Add support for libgeotiff 1.4.2.

### DIFF
--- a/include/liblas/spatialreference.hpp
+++ b/include/liblas/spatialreference.hpp
@@ -56,10 +56,10 @@
 #include <string>
 
 // Fake out the compiler if we don't have libgeotiff includes already
-#if !defined(__geotiff_h_)
+#if !defined(__geotiff_h_) && !defined(LIBGEOTIFF_GEOTIFF_H_)
 typedef struct GTIFS *GTIF;
 #endif
-#if !defined(__geo_simpletags_h_)
+#if !defined(__geo_simpletags_h_) && !defined(LIBGEOTIFF_GEO_SIMPLETAGS_H_)
 typedef struct ST_TIFFS *ST_TIFF;
 #endif
 
@@ -199,7 +199,7 @@ private:
 LAS_DLL std::ostream& operator<<(std::ostream& ostr, const liblas::SpatialReference& srs);
 
 LAS_C_START
-#if defined(__geotiff_h_)
+#if defined(__geotiff_h_) || defined(LIBGEOTIFF_GEOTIFF_H_)
 #if defined(GEO_NORMALIZE_H_INCLUDED)
 char LAS_DLL * GTIFGetOGISDefn(GTIF*, GTIFDefn*);
 #endif
@@ -210,7 +210,7 @@ void SetLinearUnitCitation(GTIF* psGTIF, char* pszLinearUOMName);
 #if defined(_OGR_SRS_API_H_INCLUDED)
 void SetGeogCSCitation(GTIF* psGTIF, OGRSpatialReference* poSRS, char* angUnitName, int nDatum, short nSpheroid);
 #endif // defined _OGR_SRS_API_H_INCLUDED
-#endif // defined __geotiff_h_
+#endif // defined __geotiff_h_ || defined LIBGEOTIFF_GEOTIFF_H_
 
 LAS_C_END
 


### PR DESCRIPTION
libLAS 1.8.0 failed to build with libgeotiff 1.4.2RC2:
```make
[ 19%] Building CXX object src/CMakeFiles/las.dir/schema.cpp.o
cd /build/liblas-1.8.0/obj-x86_64-linux-gnu/src && /usr/bin/c++   -DHAVE_GDAL=1 -DHAVE_LIBGEOTIFF=1 -Dlas_EXPORTS -I/build/liblas-1.8.0/src/../include -I/usr/include/gdal -I/usr/include/geotiff -I/usr/include/x86_64-linux-gnu  -g -O2 -fdebug-prefix-map=/build/liblas-1.8.0=. -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2   -Wextra -Wall -Wno-unused-parameter -Wno-unused-variable -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long -std=c++98 -ansi -fPIC   -o CMakeFiles/las.dir/schema.cpp.o -c /build/liblas-1.8.0/src/schema.cpp
In file included from /build/liblas-1.8.0/src/spatialreference.cpp:70:0:
/build/liblas-1.8.0/src/../include/liblas/spatialreference.hpp:60:23: error: conflicting declaration 'typedef struct GTIFS* GTIF'
 typedef struct GTIFS *GTIF;
                       ^~~~
In file included from /usr/include/geotiff/geo_normalize.h:35:0,
                 from /build/liblas-1.8.0/src/spatialreference.cpp:53:
/usr/include/geotiff/geotiff.h:59:22: note: previous declaration as 'typedef struct gtiff GTIF'
 typedef struct gtiff GTIF;   /* struct gtiff is private */
                      ^~~~
In file included from /build/liblas-1.8.0/src/spatialreference.cpp:70:0:
/build/liblas-1.8.0/src/../include/liblas/spatialreference.hpp:63:26: error: conflicting declaration 'typedef struct ST_TIFFS* ST_TIFF'
 typedef struct ST_TIFFS *ST_TIFF;
                          ^~~~~~~
In file included from /build/liblas-1.8.0/src/spatialreference.cpp:64:0:
/usr/include/geotiff/geo_simpletags.h:53:3: note: previous declaration as 'typedef struct ST_TIFF ST_TIFF'
 } ST_TIFF;
   ^~~~~~~
/build/liblas-1.8.0/src/spatialreference.cpp: In member function 'std::__cxx11::string liblas::SpatialReference::GetWKT(liblas::SpatialReference::WKTModeFlag, bool) const':
/build/liblas-1.8.0/src/spatialreference.cpp:597:55: error: 'GTIFGetOGISDefn' was not declared in this scope
         pszWKT = GTIFGetOGISDefn( m_gtiff, &sGTIFDefn );
                                                       ^
/build/liblas-1.8.0/src/spatialreference.cpp: In member function 'void liblas::SpatialReference::SetWKT(const string&)':
/build/liblas-1.8.0/src/spatialreference.cpp:688:51: error: 'GTIFSetFromOGISDefn' was not declared in this scope
     ret = GTIFSetFromOGISDefn( m_gtiff, v.c_str() );
                                                   ^
/build/liblas-1.8.0/src/spatialreference.cpp: In member function 'void liblas::SpatialReference::SetProj4(const string&)':
/build/liblas-1.8.0/src/spatialreference.cpp:817:53: error: 'GTIFSetFromOGISDefn' was not declared in this scope
     ret = GTIFSetFromOGISDefn( m_gtiff, tmp.c_str() );
                                                     ^
```
libgeotiff 1.4.2 renamed `__geotiff_h_` to `LIBGEOTIFF_GEOTIFF_H_`,
and `__geo_simpletags_h_` to `LIBGEOTIFF_GEO_SIMPLETAGS_H_`.