### PR TITLE
Fix 'offets' typo, replace with 'offset'.

### DIFF
--- a/apps/las2las.cpp
+++ b/apps/las2las.cpp
@@ -342,7 +342,7 @@ int main(int argc, char* argv[])
         if (vm.count("min-offset")) 
         {
             if (vm.count("offset")) {
-                throw std::runtime_error("min-offset cannot be used with offets.  Use one or the other");
+                throw std::runtime_error("min-offset cannot be used with offset.  Use one or the other");
             }
             
             bMinOffset = true;


### PR DESCRIPTION
The spelling error was reported by the lintian QA tool for the Debian package build of 1.8.1RC1.