### PR TITLE
Add support for GNU/kFreeBSD & GNU/Hurd

### DIFF
--- a/apps/las2col.c
+++ b/apps/las2col.c
@@ -24,7 +24,7 @@
 
 #include <limits.h>
 #include <inttypes.h>
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 
 #include <endian.h>
 #include <unistd.h>

--- a/apps/las2col.c
+++ b/apps/las2col.c
@@ -24,7 +24,7 @@
 
 #include <limits.h>
 #include <inttypes.h>
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD_kernel__)
 
 #include <endian.h>
 #include <unistd.h>

--- a/apps/las2pg.c
+++ b/apps/las2pg.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <inttypes.h>
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 
 #	include <endian.h>
 

--- a/apps/las2pg.c
+++ b/apps/las2pg.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <inttypes.h>
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD_kernel__)
 
 #	include <endian.h>
 


### PR DESCRIPTION
The endian support in las2col & las2pg needs a few extra defines to support GNU/kFreeBSD & GNU/Hurd along with GNU/Linux.