### PR TITLE
Fix spelling errors.

### DIFF
--- a/apps/las2col.c
+++ b/apps/las2col.c
@@ -160,18 +160,18 @@ void usage()
     fprintf(stderr,"----------------------------------------------------------\n");
     fprintf(stderr,"\n");
 
-    fprintf(stderr,"Convert a las/laz file into columnar format (binary) of MonetDB, outputs for each entry a file <ouput_prefix>_col_<entry_name>.dat:\n");
-    fprintf(stderr,"  las2col -i <input_file> -o <ouput_prefix>\n");
+    fprintf(stderr,"Convert a las/laz file into columnar format (binary) of MonetDB, outputs for each entry a file <output_prefix>_col_<entry_name>.dat:\n");
+    fprintf(stderr,"  las2col -i <input_file> -o <output_prefix>\n");
     fprintf(stderr,"\n");
 
-    fprintf(stderr,"Convert a list of las/laz files (still outputs for each entry a file <ouput_prefix>_col_<entry_name>.dat):\n");
-    fprintf(stderr,"  las2col -i <las_file_1> -i <las_file_2> -o <ouput_prefix>\n");
+    fprintf(stderr,"Convert a list of las/laz files (still outputs for each entry a file <output_prefix>_col_<entry_name>.dat):\n");
+    fprintf(stderr,"  las2col -i <las_file_1> -i <las_file_2> -o <output_prefix>\n");
     fprintf(stderr,"Alternatively:\n");
-    fprintf(stderr,"  las2col -f <file_with_the_list_las/laz_files> -o <ouput_prefix>\n");
+    fprintf(stderr,"  las2col -f <file_with_the_list_las/laz_files> -o <output_prefix>\n");
     fprintf(stderr,"\n");
 
     fprintf(stderr,"Convert a list of las/laz files using <num_read_threads> threads (default is 1):\n");
-    fprintf(stderr,"  las2col -f <file_with_the_list_las/laz_files> -o <ouput_prefix> --num_read_threads <number_of_threads>\n");
+    fprintf(stderr,"  las2col -f <file_with_the_list_las/laz_files> -o <output_prefix> --num_read_threads <number_of_threads>\n");
     fprintf(stderr,"\n\n");
 
     fprintf(stderr,"----------------------------------------------------------\n");
@@ -218,7 +218,7 @@ void usage()
     fprintf(stderr," After generating the columnar files, import them in MonetDB. Example: \n");
     fprintf(stderr,"   mclient <db_name> -s \"COPY BINARY INTO flat FROM ('<full_parent_path>/out_col_x.dat','<full_parent_path>/out_col_y.dat','<full_parent_path>/out_col_z.dat')\"\n");
     fprintf(stderr," Note that full paths of the columnar files MUST be used. Also note that a table called flat has to be created in a MonetDB DB beforehand. The table must have \n");
-    fprintf(stderr," the columns in the same order as specified by the --parse option, and the column types must be the ones speficied above. Example: \n");
+    fprintf(stderr," the columns in the same order as specified by the --parse option, and the column types must be the ones specified above. Example: \n");
     fprintf(stderr,"   mclient <db_name> -s \"create table flat (x double, y double, z double)\"\n");
     fprintf(stderr," Note that for decimal entries (XYZ) the column definition at table-creation time must be decimal(<num_digits_unscaled_max>,<num_digits_scale>)\n");
     fprintf(stderr," For example, if the maximum X value of a file (or a list of files) is 638982.55, then the X definition when creating the table is decimal(8,2). Example:\n");

--- a/apps/las2pg.c
+++ b/apps/las2pg.c
@@ -166,7 +166,7 @@ void usage()
     fprintf(stderr,"  las2pg -i <input_file>.las\n");
     fprintf(stderr,"\n");
 
-    fprintf(stderr,"Convert a las/laz file into PostgreSQL binary dump format, outputs <ouput_name>:\n");
+    fprintf(stderr,"Convert a las/laz file into PostgreSQL binary dump format, outputs <output_name>:\n");
     fprintf(stderr,"  las2pg -i <input_file>.las -o <output_name>\n");
     fprintf(stderr,"Use flag --stdout to write to standard output (recommended use together with a pipe, see below).\n");
     fprintf(stderr,"\n\n");
@@ -198,7 +198,7 @@ void usage()
     fprintf(stderr,"   M - vertex index number as integer\n");
     fprintf(stderr,"   k - Morton 2D code using X and Y (unscaled and no offset) as bigint\n\n");
 
-    fprintf(stderr," The moffset flag (for example '--moffset 8600000,40000000') specifies a global offset to substract to X and Y \n");
+    fprintf(stderr," The moffset flag (for example '--moffset 8600000,40000000') specifies a global offset to subtract to X and Y \n");
     fprintf(stderr," to be used when computing the Morton 2D code. Values must be unscaled \n\n");
 
     fprintf(stderr," The check flag (for example '--check 0.01,0.01') checks suitability to compute Morton 2D codes \n");
@@ -211,7 +211,7 @@ void usage()
     fprintf(stderr," The intended use of this tool is by using the --stdout flag and a pipe to avoid storing intermediate files. Example: \n");
     fprintf(stderr,"    las2pg 1.2-with-color.laz --parse xyzRGBi --stdout | psql -c \"copy flat from stdin with binary\" \n");
     fprintf(stderr," This obviously require a table called flat to be created in a PostgreSQL DB beforehand. The table must have \n");
-    fprintf(stderr," the columns in the same order as specified by the --parse option, and the column types must be the ones speficied above. Example: \n");
+    fprintf(stderr," the columns in the same order as specified by the --parse option, and the column types must be the ones specified above. Example: \n");
     fprintf(stderr,"    psql -c \"create table flat (x double precision, y double precision, z double precision, r integer, g integer, b integer, i integer)\" \n\n");
 }
 
@@ -417,7 +417,7 @@ int main(int argc, char *argv[])
     num_entries = strlen(parse_string);
 
     if (use_stdout == TRUE && file_name_out){
-      LASError_Print("If an ouput file is specified, --stdout must not be used!");
+      LASError_Print("If an output file is specified, --stdout must not be used!");
       exit(1);
     }
 


### PR DESCRIPTION
Additional spelling errors reported by the lintian QA tool, specifically in las2col & las2pg:

 ouput     -> output
 speficied -> specified
 substract -> subtract