### PR TITLE
Add basic AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,59 @@
+version: 1.8.{build}
+
+os: Visual Studio 2015
+
+platform: x64
+
+configuration: Release
+
+matrix:
+  fast_finish: true
+
+environment:
+  OSGEO4W_ROOT: C:\OSGeo4W64
+
+# Should speed up repository cloning
+shallow_clone: true
+clone_depth: 5
+
+# Uncomment if you need to debug AppVeyor session (https://www.appveyor.com/docs/how-to/rdp-to-build-worker)
+# on_finish:
+# - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+init:
+  - set PYTHONHOME=C:\Python27-x64
+  - set PYTHONPATH=%PYTHONHOME%\Lib;%OSGEO4W_ROOT%\apps\Python27\lib\site-packages
+  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+  - set PATH=%PYTHONHOME%;%PATH%
+
+install:
+  # make a temp directory for downloading osgeo4w-setup.exe
+  # this may not matter as much if part of the install step, as libLAS has
+  # already been cloned, otherwise git would complain about a non-empty
+  # directory
+  - ps: mkdir C:\temp | out-null
+  - ps: mkdir $env:OSGEO4W_ROOT | out-null
+  # make an install directory for packacing
+  - ps: mkdir C:\liblas | out-null
+  # get the OSGeo installer
+  - ps: (new-object net.webclient).DownloadFile("http://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe", "C:\temp\osgeo4w-setup.exe")
+  # and install our dependencies
+  - C:\temp\osgeo4w-setup.exe -q -k -r -A -s http://download.osgeo.org/osgeo4w/ -a x86_64 -P gdal,geos,laszip,libgeotiff,libtiff,proj,zlib -R %OSGEO4W_ROOT% > NUL
+  # call CMake configuration script
+  - call .\\bin\\appveyor\\config.cmd
+
+build:
+  parallel: true
+  project: libLAS.sln
+  verbosity: minimal
+
+test_script:
+  # FIXME: Clear PATH to avoid OSGeo4W loading incompatible DLLs
+  - set PATH=
+  - set PATH=%OSGEO4W_ROOT%\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\7-Zip;C:\Program Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Python27;C:\Tools\GitVersion;C:\Program Files (x86)\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\Program Files\AppVeyor\BuildAgent\
+  - set PYTHONHOME=C:\Python27-x64
+  - set PYTHONPATH=%PYTHONHOME%\Lib;%OSGEO4W_ROOT%\apps\Python27\lib\site-packages
+  - echo %PATH%
+  - set GDAL_DATA=%OSGEO4W_ROOT%\share\epsg_csv
+  - set PROJ_LIB=%OSGEO4W_ROOT%\share\proj
+  - ctest -V --output-on-failure -C Release

--- a/bin/appveyor/config.cmd
+++ b/bin/appveyor/config.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+cmake -G "Visual Studio 14 2015 Win64" ^
+    -DCMAKE_INSTALL_PREFIX=C:\liblas ^
+    -DBOOST_ROOT=C:\Libraries\boost_1_60_0 ^
+    -DBOOST_LIBRARYDIR=C:\Libraries\boost_1_60_0\lib64-msvc-14.0 ^
+    .

--- a/bin/appveyor/install.cmd
+++ b/bin/appveyor/install.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+cmake --build . --target install


### PR DESCRIPTION
Configure Release build with OSGeo4W and AppVeyor's Boost 1.60.

------

Note, that due to [how AppVeyor handles organizations](https://www.appveyor.com/docs/team-setup/) (requires organizational account with dedicated e-mail), I decided it is easier to host AppVeyor builds on my account:
https://ci.appveyor.com/project/mloskot/liblas