### PR TITLE
Code cleanups

### DIFF
--- a/apps/las2col.c
+++ b/apps/las2col.c
@@ -302,7 +302,6 @@ struct readThreadArgs {
 };
 
 void* writeFile(void *arg) {
-    int i = 0;
     struct writeThreadArgs *wTA = (struct writeThreadArgs*) arg;
 
     /*Obtain lock over data to get the pointer*/

--- a/apps/las2col.c
+++ b/apps/las2col.c
@@ -319,8 +319,6 @@ void* writeFile(void *arg) {
         }
 
         fwrite(dataWriteT[wTA->id].values, dataWriteT[wTA->id].type, dataWriteT[wTA->id].num_points, wTA->out);
-        //for (i = 0; i < 1000; i++)
-        //    printf("%d\n", dataWriteT[wTA->id].values[i]);
         MT_set_lock(&dataLock);
         free(dataWriteT[wTA->id].values);
         dataWriteT[wTA->id].values = NULL;

--- a/apps/las2las.cpp
+++ b/apps/las2las.cpp
@@ -260,7 +260,6 @@ int main(int argc, char* argv[])
     boost::uint32_t split_pts = 0;
     std::string input;
     std::string output;
-    std::string output_format;
     
     bool verbose = false;
     bool bMinOffset = false;

--- a/apps/las2ogr.cpp
+++ b/apps/las2ogr.cpp
@@ -134,8 +134,6 @@ void create_layer_def(OGRLayerH lyr)
 {
     assert(0 != lyr);
 
-    std::string fldname("return_num");
-
     OGRFieldDefnH fld = create_field("return_num", OFTInteger, 10, 0);
     OGRErr err = OGR_L_CreateField(lyr, fld, 0);
     if (OGRERR_NONE != err)

--- a/apps/laskernel.cpp
+++ b/apps/laskernel.cpp
@@ -873,19 +873,16 @@ std::vector<liblas::TransformPtr> GetTransforms(po::variables_map vm, bool verbo
         boost::char_separator<char> sep(SEPARATORS);
         std::vector<double> offsets;
         tokenizer tokens(offset_string, sep);
-        bool mins = false;
         std::string m("min");
         for (tokenizer::iterator t = tokens.begin(); t != tokens.end(); ++t) {
             // Check if the user set --offset min,min,min
             // FIXME: make this so the user could do --offset min,min,20.00
             if (!(*t).compare(m))
             {
-                mins = true;
                 continue;
             }
             else
             {
-                mins = false;
                 offsets.push_back(atof((*t).c_str()));
             }
         }

--- a/apps/ts2las.cpp
+++ b/apps/ts2las.cpp
@@ -369,6 +369,12 @@ int main(int argc, char* argv[])
     writer.SetFilters(filters);
     
     success = WritePoints(writer, istrm, hdr, verbose);
+ 
+    if (!success) 
+    {
+        std::cerr << "Unable to write output to " << output << std::endl; 
+        return 1;
+    }
 
     if (verbose)
     {

--- a/src/chipper.cpp
+++ b/src/chipper.cpp
@@ -190,7 +190,6 @@ int Chipper::Load()
     PtRef ref;
     uint32_t idx;
     uint32_t count;
-    vector<PtRef>::iterator it;
    
     if (Allocate())
         return -1;

--- a/src/detail/reader/zipreader.cpp
+++ b/src/detail/reader/zipreader.cpp
@@ -192,9 +192,7 @@ void ZipReaderImpl::SetHeader(liblas::Header const& header)
     
 void ZipReaderImpl::ReadIdiom()
 {
-    bool ok = false;
-
-    ok = m_unzipper->read(m_zipPoint->m_lz_point);
+    bool ok = m_unzipper->read(m_zipPoint->m_lz_point);
 
     if (!ok)
     {

--- a/src/gt_citation.cpp
+++ b/src/gt_citation.cpp
@@ -572,10 +572,10 @@ OGRBoolean CheckCitationKeyForStatePlaneUTM(GTIF* hGTIF, GTIFDefn* psDefn, OGRSp
     {
       const char *pStr = strstr( szCTString, "Projection Name = ") + strlen("Projection Name = ");
       const char* pReturn = strchr( pStr, '\n');
+#if GDAL_VERSION_NUM >=1900
       char CSName[128];
       strncpy(CSName, pStr, pReturn-pStr);
       CSName[pReturn-pStr] = '\0';
-#if GDAL_VERSION_NUM >=1900
       if( poSRS->ImportFromESRIStatePlaneWKT(0, NULL, NULL, 32767, CSName) == OGRERR_NONE )
       {
         // for some erdas citation keys, the state plane CS name is incomplete, the unit check is necessary.
@@ -645,7 +645,6 @@ OGRBoolean CheckCitationKeyForStatePlaneUTM(GTIF* hGTIF, GTIFDefn* psDefn, OGRSp
           || (pStr = strstr(szCTString, "State Plane Zone ")) != NULL )
       {
         pStr += strlen("State Plane Zone ");
-        int statePlaneZone = abs(atoi(pStr));
         char nad[32];
         strcpy(nad, "HARN");
         if( strstr(szCTString, "NAD83") || strstr(szCTString, "NAD = 83") )
@@ -653,6 +652,7 @@ OGRBoolean CheckCitationKeyForStatePlaneUTM(GTIF* hGTIF, GTIFDefn* psDefn, OGRSp
         else if( strstr(szCTString, "NAD27") || strstr(szCTString, "NAD = 27") )
           strcpy(nad, "NAD27");
 #if GDAL_VERSION_NUM >=1900
+        int statePlaneZone = abs(atoi(pStr));
         if( poSRS->ImportFromESRIStatePlaneWKT(statePlaneZone, (const char*)nad, (const char*)units, psDefn->PCS) == OGRERR_NONE )
           return TRUE;
 #endif

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -842,13 +842,9 @@ void Header::to_rst(std::ostream& os) const
     double y_scale = tree.get<double>("scale.y");
     double z_scale = tree.get<double>("scale.z");
 
-    uint32_t x_precision = 6;
-    uint32_t y_precision = 6;
-    uint32_t z_precision = 6;
-
-    x_precision = 14;//GetStreamPrecision(x_scale);
-    y_precision = 14; //GetStreamPrecision(y_scale);
-    z_precision = 14; //GetStreamPrecision(z_scale);
+    uint32_t x_precision = 14;//GetStreamPrecision(x_scale);
+    uint32_t y_precision = 14; //GetStreamPrecision(y_scale);
+    uint32_t z_precision = 14; //GetStreamPrecision(z_scale);
 
     os << "  Scale Factor X Y Z:          ";
     os.precision(x_precision);

--- a/src/spatialreference.cpp
+++ b/src/spatialreference.cpp
@@ -162,9 +162,6 @@ SpatialReference::~SpatialReference()
 /// Keep a copy of the VLRs that are related to GeoTIFF SRS information.
 void SpatialReference::SetVLRs(std::vector<VariableRecord> const& vlrs)
 {
-
-    std::string const uid("LASF_Projection");
-
     // Wipe out any existing VLRs that might exist on the SpatialReference
     m_vlrs.clear();
 


### PR DESCRIPTION
- removes unused variables
- moves assignments around #ifdef to avoid unused vars
- checks return value and errors out when it should (ts2las.cpp)
- avoids redundant assignments