### PR TITLE
Memory leak in the C API

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -27,6 +27,7 @@ if (NOT WIN32)
 endif()
 
 set(BIGFILE_TEST bigfile_test)
+set(MEMLEAK_TEST memleak_test)
 set(LASINDEX_TEST lasindex_test)
 
 if(Boost_IOSTREAMS_FOUND)
@@ -147,6 +148,12 @@ if(BIGFILE_TEST)
     add_executable(${BIGFILE_TEST} bigtest.c)
     target_link_libraries(${BIGFILE_TEST} ${LIBLAS_C_LIB_NAME})
 endif()
+
+if(MEMLEAK_TEST)
+    add_executable(${MEMLEAK_TEST} memleak_test.c)
+    target_link_libraries(${MEMLEAK_TEST} ${LIBLAS_C_LIB_NAME})
+endif()
+
 
 if (LASINDEX_TEST)
     add_executable(${LASINDEX_TEST} lasindex_test.cpp)

--- a/apps/memleak_test.c
+++ b/apps/memleak_test.c
@@ -1,0 +1,58 @@
+#include <liblas.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void dumperror (const char * appmsg)
+{
+   printf("\n%s.\n\tMessage:  %s\n\tMethod: %s",appmsg, LASError_GetLastErrorMsg(), LASError_GetLastErrorMethod());
+}
+int main()
+{
+
+    LASHeaderH header = NULL;
+    LASWriterH writer = NULL;
+    LASReaderH reader = NULL;
+    LASPointH pt = NULL;
+    LASError err;
+	const unsigned long nMillionPoints = 1;
+    const unsigned long NPOINTS = 1024*1024*nMillionPoints ;
+    const char * OutputName = "Issue147.las";
+    unsigned long i = 0;
+    unsigned long npoints = 0;
+
+    // Write a LAS file and after the points are in, update the header.
+    header = LASHeader_Create();
+    writer = LASWriter_Create(OutputName, header, LAS_MODE_WRITE);
+    
+    for (i = 0; i < NPOINTS; i++)
+    {
+      if (i % 1000 == 0)
+         printf("\b\b\b\b\b\b\b%6.2f%%", ((double)i)/NPOINTS * 100.0);
+      
+      pt = LASPoint_Create();
+      err = LASPoint_SetX(pt, 0);
+      if (err) printf ("For point %lu, failed to set point value X\n", i);
+      err = LASPoint_SetY(pt, 0);
+      if (err) printf ("For point %lu, failed to set point value Y\n", i);
+      err = LASPoint_SetZ(pt, 0);
+      if (err) printf ("For point %lu, failed to set point value Z\n", i);
+      err = LASWriter_WritePoint(writer, pt);  
+      if (err) printf ("For point %lu, failed to WritePoint\n", i);
+      LASPoint_Destroy(pt);
+    }
+   err = LASHeader_SetPointRecordsCount(header, NPOINTS);
+   if (err) dumperror ("Failed to LASHeader_SetPointRecordsCount\n");
+   err = LASWriter_WriteHeader(writer, header);
+   if (err) dumperror ("Failed to LASWriter_WriteHeader");
+   LASWriter_Destroy(writer);
+   LASHeader_Destroy(header);
+   
+   // Read the file we just wrote and check the header data.
+    reader = LASReader_Create(OutputName);
+    header = LASReader_GetHeader(reader);
+    npoints = LASHeader_GetPointRecordsCount(header);
+	printf ("\n\nWrote %lu, Read %lu (testing %lu Million (1024 x 1024) Points)\n", NPOINTS, npoints, nMillionPoints);
+	LASHeader_Destroy(header);
+	LASReader_Destroy(reader);
+}

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1558,8 +1558,8 @@ LAS_DLL char* LASHeader_GetXML(const LASHeaderH hHeader)
 LAS_DLL void LASHeader_Destroy(LASHeaderH hHeader)
 {
     VALIDATE_LAS_POINTER0(hHeader, "LASHeader_Destroy");
-    // delete ((liblas::Header*) hHeader);
-    // hHeader=NULL;
+    delete ((liblas::HeaderPtr*) hHeader);
+    hHeader=NULL;
 }
 
 LAS_DLL LASHeaderH LASHeader_Copy(const LASHeaderH hHeader) {


### PR DESCRIPTION
Hi,

running applications that use the C API through valgrind, I realized that headers were not deallocated correctly. Going through the code I saw that the function LASHeader_Destroy was actually a no-op. 

This pull request adds a small test (a modified version of the bigfile_test), and changes the LASHeader_Destroy to deallocate the header. 

Please bear in mind that my C++ is very rusty, and this might very well not be the correct way to go about fixing the issue, however I have not encountered any problems so far.

Thanks,
Panos.