### PR TITLE
Add support for liblas_c.so.2

### DIFF
--- a/python/liblas/core.py
+++ b/python/liblas/core.py
@@ -154,8 +154,12 @@ elif os.name == 'posix':
         free = ctypes.CDLL(find_library('libc')).free
     else:
         lib_name = 'liblas_c.so.3'
+        lib_name_alt = 'liblas_c.so.2'
         free = ctypes.CDLL(find_library('c')).free
-    las = ctypes.CDLL(lib_name)
+    try:
+        las = ctypes.CDLL(lib_name)
+    except:
+        las = ctypes.CDLL(lib_name_alt)
 else:
     raise LASException('Unsupported OS "%s"' % os.name)
 


### PR DESCRIPTION
Using the Ubuntu packages (https://launchpad.net/ubuntu/+source/liblas), only "liblas_c.so.2" is installed, therefore, this script raises an exception saying "liblas_c.so.3" could not be found. I fixed this by additionally searching for "liblas_c.so.2" when the other version is not available.