### PR TITLE
gt_citation.cpp: fix compilation against GDAL 2.3

### DIFF
--- a/src/gt_citation.cpp
+++ b/src/gt_citation.cpp
@@ -387,10 +387,10 @@ void SetGeogCSCitation(GTIF * psGTIF, OGRSpatialReference *poSRS, char* angUnitN
         osCitation += primemName;
         bRewriteGeogCitation = TRUE;
 
-        double primemValue = poSRS->GetPrimeMeridian(NULL);
+        double primemValue = poSRS->GetPrimeMeridian();
         if(angUnitName && !EQUAL(angUnitName, "Degree"))
         {
-            double aUnit = poSRS->GetAngularUnits(NULL);
+            double aUnit = poSRS->GetAngularUnits();
             primemValue *= aUnit;
         }
         GTIFKeySet( psGTIF, GeogPrimeMeridianLongGeoKey, TYPE_DOUBLE, 1, 


### PR DESCRIPTION
The call to GetAngularUnits(NULL) is ambiguous since there is now
```
    double      GetAngularUnits( char ** ) const CPL_WARN_DEPRECATED("Use GetAngularUnits(const char**) instead");
    double      GetAngularUnits( const char ** = nullptr ) const;
    double      GetAngularUnits( std::nullptr_t ) const
```
But GetAngularUnits(NULL) doesn't match GetAngularUnits( std::nullptr_t )

This change is also compatible of previous GDAL version