### PR TITLE
 GDAL interface: no longer use deprecated API of GDAL 2.3 

### DIFF
--- a/src/gt_citation.cpp
+++ b/src/gt_citation.cpp
@@ -387,10 +387,10 @@ void SetGeogCSCitation(GTIF * psGTIF, OGRSpatialReference *poSRS, char* angUnitN
         osCitation += primemName;
         bRewriteGeogCitation = TRUE;
 
-        double primemValue = poSRS->GetPrimeMeridian(NULL);
+        double primemValue = poSRS->GetPrimeMeridian();
         if(angUnitName && !EQUAL(angUnitName, "Degree"))
         {
-            double aUnit = poSRS->GetAngularUnits(NULL);
+            double aUnit = poSRS->GetAngularUnits();
             primemValue *= aUnit;
         }
         GTIFKeySet( psGTIF, GeogPrimeMeridianLongGeoKey, TYPE_DOUBLE, 1, 

--- a/src/gt_citation.cpp
+++ b/src/gt_citation.cpp
@@ -308,7 +308,7 @@ char** CitationStringParse(char* psCitation, geokey_t keyID)
 /*                                                                      */
 /*      Set linear unit Citation string                                 */
 /************************************************************************/
-void SetLinearUnitCitation(GTIF* psGTIF, char* pszLinearUOMName)
+void SetLinearUnitCitation(GTIF* psGTIF, const char* pszLinearUOMName)
 {
     char szName[512];
     CPLString osCitation;
@@ -338,7 +338,7 @@ void SetLinearUnitCitation(GTIF* psGTIF, char* pszLinearUOMName)
 /*                                                                      */
 /*      Set geogcs Citation string                                      */
 /************************************************************************/
-void SetGeogCSCitation(GTIF * psGTIF, OGRSpatialReference *poSRS, char* angUnitName, int nDatum, short nSpheroid)
+void SetGeogCSCitation(GTIF * psGTIF, OGRSpatialReference *poSRS, const char* angUnitName, int nDatum, short nSpheroid)
 {
     int bRewriteGeogCitation = FALSE;
     char szName[256];

--- a/src/gt_citation.h
+++ b/src/gt_citation.h
@@ -55,8 +55,8 @@ typedef enum
 OGRBoolean CheckCitationKeyForStatePlaneUTM(GTIF* hGTIF, GTIFDefn* psDefn, OGRSpatialReference* poSRS, OGRBoolean* pLinearUnitIsSet);
 //char* ImagineCitationTranslation(char* psCitation, geokey_t keyID);
 //char** CitationStringParse(char* psCitation, geokey_t keyID);
-void SetLinearUnitCitation(GTIF* psGTIF, char* pszLinearUOMName);
-void SetGeogCSCitation(GTIF * psGTIF, OGRSpatialReference *poSRS, char* angUnitName, int nDatum, short nSpheroid);
+void SetLinearUnitCitation(GTIF* psGTIF, const char* pszLinearUOMName);
+void SetGeogCSCitation(GTIF * psGTIF, OGRSpatialReference *poSRS, const char* angUnitName, int nDatum, short nSpheroid);
 OGRBoolean SetCitationToSRS(GTIF* hGTIF, char* szCTString, int nCTStringLen,
                             geokey_t geoKey, OGRSpatialReference* poSRS, OGRBoolean* linearUnitIsSet);
 void GetGeogCSFromCitation(char* szGCSName, int nGCSName,

--- a/src/gt_wkt_srs.cpp
+++ b/src/gt_wkt_srs.cpp
@@ -1196,7 +1196,11 @@ int GTIFSetFromOGISDefn( GTIF * psGTIF, const char *pszOGCWKT )
 /*      string.                                                         */
 /* -------------------------------------------------------------------- */
     poSRS = new OGRSpatialReference();
+#if GDAL_VERSION_MAJOR > 2 || (GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR >= 3)
+    if( poSRS->importFromWkt(pszOGCWKT) != OGRERR_NONE )
+#else
     if( poSRS->importFromWkt((char **) &pszOGCWKT) != OGRERR_NONE )
+#endif
     {
         delete poSRS;
         return FALSE;
@@ -1262,7 +1266,11 @@ int GTIFSetFromOGISDefn( GTIF * psGTIF, const char *pszOGCWKT )
 /* -------------------------------------------------------------------- */
 /*      Get the linear units.                                           */
 /* -------------------------------------------------------------------- */
+#if GDAL_VERSION_MAJOR > 2 || (GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR >= 3)
+    const char  *pszLinearUOMName = NULL;
+#else
     char        *pszLinearUOMName = NULL;
+#endif
     double	dfLinearUOM = poSRS->GetLinearUnits( &pszLinearUOMName );
     int         nUOMLengthCode = 9001; /* meters */
 
@@ -2161,8 +2169,11 @@ int GTIFSetFromOGISDefn( GTIF * psGTIF, const char *pszOGCWKT )
 /*      Write angular units.  Always Degrees for now.                   */
 /*   Changed to support different angular units                         */
 /* -------------------------------------------------------------------- */
-
+#if GDAL_VERSION_MAJOR > 2 || (GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR >= 3)
+    const char* angUnitName = NULL;
+#else
     char* angUnitName = NULL;
+#endif
     double angUnitValue = poSRS->GetAngularUnits(&angUnitName);
     if(EQUAL(angUnitName, "Degree"))
         GTIFKeySet(psGTIF, GeogAngularUnitsGeoKey, TYPE_SHORT, 1,

--- a/src/spatialreference.cpp
+++ b/src/spatialreference.cpp
@@ -602,8 +602,12 @@ std::string SpatialReference::GetWKT(WKTModeFlag mode_flag , bool pretty) const
 
         if (pretty) {
             OGRSpatialReference* poSRS = (OGRSpatialReference*) OSRNewSpatialReference(NULL);
+#if GDAL_VERSION_MAJOR > 2 || (GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR >= 3)
+            poSRS->importFromWkt( pszWKT );
+#else
             char *pszOrigWKT = pszWKT;
             poSRS->importFromWkt( &pszOrigWKT );
+#endif
 
             CPLFree( pszWKT );
             pszWKT = NULL;
@@ -623,8 +627,12 @@ std::string SpatialReference::GetWKT(WKTModeFlag mode_flag , bool pretty) const
             && strstr(pszWKT,"COMPD_CS") != NULL )
         {
             OGRSpatialReference* poSRS = (OGRSpatialReference*) OSRNewSpatialReference(NULL);
+#if GDAL_VERSION_MAJOR > 2 || (GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR >= 3)
+            poSRS->importFromWkt( pszWKT );
+#else
             char *pszOrigWKT = pszWKT;
             poSRS->importFromWkt( &pszOrigWKT );
+#endif
 
             CPLFree( pszWKT );
             pszWKT = NULL;
@@ -661,7 +669,7 @@ void SpatialReference::SetFromUserInput(std::string const& v)
 
     // OGRSpatialReference* poSRS = (OGRSpatialReference*) OSRNewSpatialReference(NULL);
     OGRSpatialReference srs(NULL);
-    if (OGRERR_NONE != srs.SetFromUserInput(const_cast<char *> (input)))
+    if (OGRERR_NONE != srs.SetFromUserInput(input))
     {
         throw std::invalid_argument("could not import coordinate system into OSRSpatialReference SetFromUserInput");
     }
@@ -760,7 +768,11 @@ std::string SpatialReference::GetProj4() const
     const char* poWKT = wkt.c_str();
 
     OGRSpatialReference srs(NULL);
+#if GDAL_VERSION_MAJOR > 2 || (GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR >= 3)
+    if (OGRERR_NONE != srs.importFromWkt(poWKT))
+#else
     if (OGRERR_NONE != srs.importFromWkt(const_cast<char **> (&poWKT)))
+#endif
     {
         return std::string();
     }


### PR DESCRIPTION
This applies on top of https://github.com/libLAS/libLAS/pull/133