### PR TITLE
WITH_GDAL: fix build with -DDEBUG

### DIFF
--- a/src/spatialreference.cpp
+++ b/src/spatialreference.cpp
@@ -578,7 +578,7 @@ std::string SpatialReference::GetWKT(WKTModeFlag mode_flag , bool pretty) const
             else
                 poSRS->exportToWkt( &pszWKT );
 
-            OSRDestroySpatialReference( poSRS );
+            OGRSpatialReference::DestroySpatialReference( poSRS );
 
             result_wkt = pszWKT;
             CPLFree( pszWKT );
@@ -608,7 +608,7 @@ std::string SpatialReference::GetWKT(WKTModeFlag mode_flag , bool pretty) const
             CPLFree( pszWKT );
             pszWKT = NULL;
             poSRS->exportToPrettyWkt(&pszWKT, false);
-            OSRDestroySpatialReference( poSRS );
+            OGRSpatialReference::DestroySpatialReference( poSRS );
 
         }
 
@@ -635,7 +635,7 @@ std::string SpatialReference::GetWKT(WKTModeFlag mode_flag , bool pretty) const
             else
                 poSRS->exportToWkt( &pszWKT );
 
-            OSRDestroySpatialReference( poSRS );
+            OGRSpatialReference::DestroySpatialReference( poSRS );
         }
 #else
         boost::ignore_unused_variable_warning(mode_flag);


### PR DESCRIPTION
In DEBUG mode, OGRSpatialReference* and OGRSpatialReferenceH are not freely interchangeable in the C API