### PR TITLE
cmake: install liblas-config.cmake into lib/cmake

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -6,7 +6,7 @@
 # ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR} and ${PROJECT_ROOT_DIR}
 # is the relative path to the root from there.
 if (NOT WIN32)
-  set(INSTALL_CMAKE_DIR "share/cmake/${PROJECT_NAME}")
+  set(INSTALL_CMAKE_DIR "${LIBLAS_LIB_DIR}/cmake/${PROJECT_NAME}")
   set (PROJECT_ROOT_DIR "../../..")
 else ()
   set(INSTALL_CMAKE_DIR "cmake")


### PR DESCRIPTION
This is required because liblas-config.cmake refers to arch-specific
locations. Without this, 32bit liblas-config.cmake conflicts with 64bit
liblas-config.cmake on multi-arch distributions.