### PR TITLE
cmake: set CMAKE_MACOSX_RPATH to `OFF` explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,7 @@ mark_as_advanced(CMAKE_VERBOSE_MAKEFILE)
 
 # Path to additional CMake modules
 set(CMAKE_MODULE_PATH "${libLAS_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
-if (CMAKE_MAJOR_VERSION GREATER 2)
-    cmake_policy(SET CMP0042 OLD)
-endif()
+set(CMAKE_MACOSX_RPATH OFF)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 set(CMAKE_SKIP_RPATH ON)


### PR DESCRIPTION
CMake policy settings of `OLD` are not meant to be used as workarounds
for CMake's behavior changes. Instead, just set the property to `OFF` as
this is what setting the policy to `OLD` effectively does.