### PR TITLE
Fix compiling problem when WITH_GEOTIFF is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,8 @@ if(WITH_GEOTIFF)
   else()
     message(FATAL_ERROR "Unable to find sufficient GeoTIFF")
   endif()
+else()
+  set(GEOTIFF_LIBRARY "")
 endif()
 
 


### PR DESCRIPTION
This fixes compiling problem when WITH_GEOTIFF is disabled, as GEOTIFF_LIBRARY is required by src/CMakeLists.txt, which has to be defined.