### PR TITLE
Fix header missing from las2txt output

### DIFF
--- a/apps/las2txt.cpp
+++ b/apps/las2txt.cpp
@@ -286,6 +286,8 @@ std::string GetHeader(liblas::Reader& reader)
     boost::ignore_unused_variable_warning(reader);
 
     std::ostringstream oss;
+  
+    oss << reader.GetHeader();
 
     return oss.str();
 }


### PR DESCRIPTION
I was trying to get the .las file header, but it was impossible.
With this change I finally figured it out.
Thanks!