### PR TITLE
Always return NULL when Open() is used

### DIFF
--- a/include/liblas/liblas.hpp
+++ b/include/liblas/liblas.hpp
@@ -138,6 +138,7 @@ inline std::istream* Open(std::string const& filename, std::ios::openmode mode) 
         ifs = new std::ifstream();
         ifs->open(filename.c_str(), mode);
         if (ifs->is_open() == false) return NULL;
+        return ifs;
     }
     catch (...)
     {


### PR DESCRIPTION
I was trying to use las2las to filter some points.
I always received : "Cannot open sample.las for read.  Exiting..."
The problem was that Open() didn't "return ifs" properly.
Thank you!