### PR TITLE
Fix segfault by handling a case when Open returns NULL

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -243,6 +243,12 @@ LAS_DLL LASReaderH LASReader_Create(const char* filename)
         return NULL;
     }
 
+    if (istrm == NULL) {
+        delete istrm;
+        LASError_PushError(LE_Failure, "Something went wrong while opening the file", "LASReader_Create");
+        return NULL;
+    }
+
     try {
         liblas::ReaderFactory f;
         liblas::Reader* reader = new liblas::Reader(f.CreateWithStream(*istrm));
@@ -273,6 +279,12 @@ LAS_DLL LASReaderH LASReader_CreateWithHeader(  const char* filename,
     {
         if (istrm) delete istrm;
         LASError_PushError(LE_Failure, e.what(), "LASReader_Create");
+        return NULL;
+    }
+
+    if (istrm == NULL) {
+        delete istrm;
+        LASError_PushError(LE_Failure, "Something went wrong while opening the file", "LASReader_Create");
         return NULL;
     }
 


### PR DESCRIPTION
std::istream* Open can return NULL as a result instead of throwing an exception. C API handles exceptions but does not check for NULL return value. Further manipulations with NULL pointer eventually lead to a segfault.