### PR TITLE
cmake: don't force rpath settings on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,6 @@ mark_as_advanced(CMAKE_VERBOSE_MAKEFILE)
 
 # Path to additional CMake modules
 set(CMAKE_MODULE_PATH "${libLAS_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
-set(CMAKE_MACOSX_RPATH OFF)
 
 ###############################################################################
 # General build settings

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -248,17 +248,6 @@ target_include_directories(las_c
     $<BUILD_INTERFACE:${libLAS_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${LIBLAS_INCLUDE_DIR}>)
 
-if (APPLE)
-  set_target_properties(
-    las_c
-    PROPERTIES
-    INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-  set_target_properties(
-    las
-    PROPERTIES
-    INSTALL_NAME_DIR "@rpath" BUILD_WITH_INSTALL_RPATH ON)
-endif()
-
 ###############################################################################
 # Targets installation.  The EXPORT clause specifies a depends target
 # which packages up information about the libraries for


### PR DESCRIPTION
Using rpath on macOS is tricky at best. Instead of forcing all macOS
users to deal with it, some package managers (e.g., MacPorts) avoid
@rpath completely. This logic forces settings on the deployment system
without a way to override it. These are best left controlled by the
`CMAKE_` variables which handle these properties by the user.