### PR TITLE
Avoid double-free when Header is passed into File.__init__

### DIFF
--- a/python/liblas/file.py
+++ b/python/liblas/file.py
@@ -98,13 +98,10 @@ class File(object):
         else:
             self.filename = filename
         self._header = None
-        self.ownheader = True
 
         # import pdb;pdb.set_trace()
-        if header != None:
-
-            self.ownheader = False
-            self._header = header.handle
+        if header is not None:
+            self._header = core.las.LASHeader_Copy(header.handle)
 
         self.handle = None
         self._mode = mode.lower()


### PR DESCRIPTION
This PR addresses memory corruption in the python bindings caused by a double-free.

**The Problem**

When a `liblas.file.Header` is passed in to the `liblas.file.File` as a constructor parameter, its handle is copied to `self._header` and `self.ownheader` is set to `False`, but ` self.ownheader` is never read, and the rest of `class File` assumes it can call `LASHeader_Destroy(self._header)`.

When Python garbage collection runs, it calls `__del__` on the `Header` which results in its handle being destroyed. But, since creating the `File` already destroyed that handle (on one of the branches of `File.open`), this causes memory errors.

**This PR**

The simplest fix I could think of was to simply always copy the incoming handle and remove `self.ownheader` entirely.

**An alternative**

If you'd prefer a fix that honors `ownheader`, I've implemented that too as branch [`fix-python-double-free-alternate`](https://github.com/libLAS/libLAS/compare/master...drmoose:fix-python-double-free-alternate).