### PR TITLE
Clarification of Get{X,Y,Z} documentation

### DIFF
--- a/include/liblas/point.hpp
+++ b/include/liblas/point.hpp
@@ -111,10 +111,10 @@ public:
     Point& operator=(Point const& rhs);
 
     /// Returns the scaled and shifted X-coordinate. Scaling and shifting (offset) parameters are defined in the header.
-	double GetX() const;
-	/// Returns the scaled and shifted Y-coordinate. Scaling and shifting (offset) parameters are defined in the header.
+    double GetX() const;
+    /// Returns the scaled and shifted Y-coordinate. Scaling and shifting (offset) parameters are defined in the header.
     double GetY() const;
-	/// Returns the scaled and shifted Z-coordinate. Scaling and shifting (offset) parameters are defined in the header.
+    /// Returns the scaled and shifted Z-coordinate. Scaling and shifting (offset) parameters are defined in the header.
     double GetZ() const;
     
     int32_t GetRawX() const;

--- a/include/liblas/point.hpp
+++ b/include/liblas/point.hpp
@@ -110,8 +110,11 @@ public:
     Point(Point const& other);
     Point& operator=(Point const& rhs);
 
-    double GetX() const;
+    /// Returns the scaled and shifted X-coordinate. Scaling and shifting (offset) parameters are defined in the header.
+	double GetX() const;
+	/// Returns the scaled and shifted Y-coordinate. Scaling and shifting (offset) parameters are defined in the header.
     double GetY() const;
+	/// Returns the scaled and shifted Z-coordinate. Scaling and shifting (offset) parameters are defined in the header.
     double GetZ() const;
     
     int32_t GetRawX() const;


### PR DESCRIPTION
Make it clear that the GetX(),GetY(),GetZ() functions return the scaled and shifted coordinate values.

As a novice to libLAS it was not clear to me that these functions already applied the scaling and offset factors. 