### PR TITLE
Fix syntax error that occurs with gcc11

### DIFF
--- a/include/liblas/bounds.hpp
+++ b/include/liblas/bounds.hpp
@@ -186,7 +186,7 @@ private:
     
 public:
 
-Bounds<T>()
+Bounds()
 {
     ranges.resize(0);
 }


### PR DESCRIPTION
Small fix for a syntax error that occurs using gcc11 / c++20 mode. See [here](https://timsong-cpp.github.io/cppwp/n4861/diff.cpp17.class#2) for details:
