### PR TITLE
Fix out of bounds error when filtering with 2D bounds

### DIFF
--- a/include/liblas/bounds.hpp
+++ b/include/liblas/bounds.hpp
@@ -456,13 +456,17 @@ bool contains(Point const& point) const
         return false;
     if (!ranges[1].contains(point.GetY()))
         return false;
-        
-    // If our z bounds has no length, we'll say it's contained anyway.
-    if (!ranges[2].contains(point.GetZ())) 
+
+    // Only check Z if we have 3 dimensional bounds
+    if (ranges.size() > 2)
     {
-        if (detail::compare_distance(ranges[2].length(), 0.0))
-            return true;
-        return false;
+    // If our z bounds has no length, we'll say it's contained anyway.
+        if (!ranges[2].contains(point.GetZ())) 
+        {
+            if (detail::compare_distance(ranges[2].length(), 0.0))
+                return true;
+            return false;
+        }
     }
     return true;
 }

--- a/include/liblas/bounds.hpp
+++ b/include/liblas/bounds.hpp
@@ -452,6 +452,11 @@ bool contains(Point const& point) const
     //           << " r.z.min: " << ranges[2].min 
     //           << " r.z.max: " << ranges[2].max 
     //           << " p.z: " << point.GetZ() << std::endl;
+
+    
+    if (ranges.size() < 2) 
+        return false;
+    
     if (!ranges[0].contains(point.GetX()))
         return false;
     if (!ranges[1].contains(point.GetY()))

--- a/include/liblas/detail/endian.hpp
+++ b/include/liblas/detail/endian.hpp
@@ -88,6 +88,7 @@
    || defined(_M_ALPHA) || defined(__amd64) \
    || defined(__amd64__) || defined(_M_AMD64) \
    || defined(__x86_64) || defined(__x86_64__) \
+   || defined(__arm64) || defined(__arm64__) \
    || defined(_M_X64)
 
 # define LIBLAS_LITTLE_ENDIAN


### PR DESCRIPTION
Fixes an out of bounds error when reading with a bounds filter with a 2D bounds. 