### PR TITLE
Update required Boost modules list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,11 +184,13 @@ if(WIN32)
 endif(WIN32)
 
 find_package(Threads)
-find_package(Boost 1.42 COMPONENTS program_options thread system iostreams filesystem REQUIRED)
+find_package(Boost 1.42 COMPONENTS iostreams program_options serialization thread REQUIRED)
 
-if(Boost_FOUND AND Boost_PROGRAM_OPTIONS_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
+# The following header-only and their dependencies are additionally required,
+# but cannot be explicitly requested via find_package, so make sure they exists:
+# - foreach interprocess lambda property_tree uuid
+
+include_directories(${Boost_INCLUDE_DIRS})
 
 # make these available for the user to set.
 mark_as_advanced(CLEAR Boost_INCLUDE_DIR)


### PR DESCRIPTION
Currently I had the issue that a required Boost library was not requested, as `foreach` is a separate module (see https://github.com/microsoft/vcpkg/pull/30950). On the other side modules were requested, which are not required (`filesystem`).

So I checked which modules are really required im several steps:

1) Search for `#include.*boost/.*/` within current `master` branch, sort and deduplicate entries and check within with git submodule of Boost the required headers can be found (`<boost_root>\boost\\libs\<submodule>\include\<requested_header>`):
   ```
   boost/algorithm/string/erase.hpp // algorithm
   boost/any.hpp // any
   boost/array.hpp // array
   boost/bind.hpp // bind
   boost/concept_check.hpp // concept_check
   boost/config.hpp // config
   boost/cstdint.hpp // config
   boost/foreach.hpp // foreach
   boost/function.hpp // function
   boost/interprocess/file_mapping.hpp // interprocess
   boost/interprocess/mapped_region.hpp // interprocess
   boost/iostreams/device/file.hpp // iostreams
   boost/iostreams/device/file_descriptor.hpp // iostreams
   boost/iostreams/positioning.hpp // iostreams
   boost/iostreams/stream.hpp // iostreams
   boost/iostreams/stream_buffer.hpp // iostreams
   boost/iterator/iterator_adaptor.hpp // iterator
   boost/iterator/reverse_iterator.hpp // iterator
   boost/lambda/lambda.hpp // lambda
   boost/lexical_cast.hpp // lexical_cast
   boost/limits.hpp // config
   boost/mpl/and.hpp // mpl
   boost/mpl/has_xxx.hpp //mpl
   boost/multi_index/hashed_index.hpp // multi_index
   boost/multi_index/indexed_by.hpp // multi_index
   boost/multi_index/mem_fun.hpp // multi_index
   boost/multi_index/member.hpp // multi_index
   boost/multi_index/ordered_index.hpp // multi_index
   boost/multi_index/random_access_index.hpp // multi_index
   boost/multi_index/sequenced_index.hpp // multi_index
   boost/multi_index_container.hpp // multi_index
   boost/next_prior.hpp // iterator
   boost/optional.hpp // optional
   boost/optional/optional_fwd.hpp // optional
   boost/optional/optional_io.hpp // optional
   boost/program_options.hpp // program_options
   boost/property_tree/detail/info_parser_error.hpp // property_tree
   boost/property_tree/detail/info_parser_utils.hpp // property_tree
   boost/property_tree/ptree.hpp // property_tree
   boost/scoped_array.hpp // smart_ptr
   boost/scoped_ptr.hpp // smart_ptr
   boost/serialization/collections_load_imp.hpp // serialization
   boost/serialization/collections_save_imp.hpp // serialization
   boost/serialization/nvp.hpp // serialization
   boost/serialization/split_free.hpp // serialization
   boost/serialization/utility.hpp // serialization
   boost/shared_ptr.hpp // smart_ptr
   boost/spirit/include/classic.hpp // spirit
   boost/static_assert.hpp // static_assert
   boost/thread/once.hpp // thread
   boost/throw_exception.hpp // throw_exception
   boost/tokenizer.hpp // tokenizer
   boost/type_traits/decay.hpp // type_traits
   boost/type_traits/integral_constant.hpp // type_traits
   boost/type_traits/is_same.hpp // type_traits
   boost/type_traits/is_signed.hpp // type_traits
   boost/type_traits/make_unsigned.hpp // type_traits
   boost/unordered_map.hpp // unordered
   boost/utility.hpp // utility
   boost/utility/enable_if.hpp // utility
   boost/uuid/uuid.hpp // uuid
   boost/uuid/uuid_generators.hpp // uuid
   boost/uuid/uuid_io.hpp // uuid
   ```
2. Check the list of modules, whether they are already required by at least one other modules by using the [latest dependency report](https://pdimov.github.io/boostdep-report/) (in the hope there is no relevant change since Boost 1.42):
   ```
   algorithm => thread
   any => program_options
   array => array
   bind => program_options
   concept_check => concept_check
   config => program_options
   foreach => no dependency of other required module
   function => program_options
   interprocess => no dependency of other required module
   iostreams => no dependency of other required module
   iterator => program_options
   lambda => no dependency of other required module
   lexical_cast => program_options
   mpl => iostreams
   multi_index => property_tree
   optional => property_tree
   program_options => no dependency of other required module
   property_tree => no dependency of other required module
   serialization => property_tree 
   smart_ptr => program_options
   spirit => serialization
   static_assert => program_options
   thread => spirit
   throw_exception => program_options
   tokenizer => program_options
   type_traits => program_options
   unordered => serialization
   utility => serialization
   uuid => no dependency of other required module
   ```
3. Check remaining list which components are header only, as the CMake script `FindBoost` doesn't like Header-Only libraries within the `COMPONENT` parameter:
   ```
   foreach => header-only
   interprocess => header-only
   iostreams
   lambda => header-only
   program_options
   property_tree => header-only
   uuid => header-only
   ```
4. Check which components [needs to be linked](https://www.boost.org/doc/libs/1_82_0/more/getting_started/unix-variants.html#header-only-libraries) and are missing in last list as it was removed due to a header-only list before => `serialization` and `thread` are additionally required.

Note: The check `if(Boost_FOUND AND Boost_PROGRAM_OPTIONS_FOUND)` should not be necessary as `find_package` is throwing an fatal error in case sth. is missing due to the `REQUIRED`
