### PR TITLE
Synchronize Boost dependencies

### DIFF
--- a/cmake/liblas-config.cmake.in
+++ b/cmake/liblas-config.cmake.in
@@ -15,7 +15,7 @@ if (NOT libLAS_FIND_QUIETLY)
 endif ()
 
 include (CMakeFindDependencyMacro)
-find_dependency (Boost @Boost_VERSION_STRING@ EXACT COMPONENTS program_options thread system iostreams filesystem)
+find_dependency (Boost @Boost_VERSION_STRING@ EXACT COMPONENTS iostreams program_options serialization thread)
 
 # Tell the user project where to find our headers and libraries
 get_filename_component (_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)


### PR DESCRIPTION
Currently configuring VTK with libLAS fails with:
```
-- Reading /usr/lib64/cmake/libLAS/liblas-config.cmake
-- libLAS configuration, version 1.8.2b1
-- Found Boost: /usr/lib64/cmake/Boost-1.83.0/BoostConfig.cmake (found suitable exact version "1.83.0") found components: program_options thread system iostreams filesystem 
-- Found CGNS: /usr/include (found suitable version "4.40", minimum required is "4.10") 
-- Found Boost: /usr/lib64/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0") found components: serialization 
-- Found GDAL: /usr/lib64/libgdal.so (found version "3.8.4") 
-- Found Boost: /usr/lib64/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0")  
-- Found OpenSlide: /usr/lib64/libopenslide.so  
-- Found LibArchive: /usr/lib64/libarchive.so (found version "3.7.2") 
-- Could NOT find Git (missing: GIT_EXECUTABLE) 
-- Could not use git to determine source version, using version 2.0.0
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of Wrapped_MPI_Comm
-- Check size of Wrapped_MPI_Comm - done
-- Check size of Wrapped_MPI_Datatype
-- Check size of Wrapped_MPI_Datatype - done
-- Check size of Wrapped_MPI_Status
-- Check size of Wrapped_MPI_Status - done
-- Check size of Wrapped_MPI_Request
-- Check size of Wrapped_MPI_Request - done
-- Check size of Wrapped_MPI_Op
-- Check size of Wrapped_MPI_Op - done
-- Check size of Wrapped_MPI_File
-- Check size of Wrapped_MPI_File - done
-- Check size of Wrapped_MPI_Win
-- Check size of Wrapped_MPI_Win - done
-- Found GLUT: /usr/lib64/libglut.so  
-- Found WrapAtomic: TRUE  
-- Found Java: /usr/lib/jvm/java/bin/java (found version "21.0.2") found components: Development 
-- Found Java: /usr/lib/jvm/java/bin/java (found version "21.0.2") found components: Runtime Development 
-- Found Doxygen: /usr/bin/doxygen (found version "1.10.0") found components: doxygen dot 
-- Found Perl: /usr/bin/perl (found version "5.38.2") 
-- Configuring done (28.5s)
CMake Error at /usr/lib64/cmake/libLAS/liblas-depends.cmake:68 (add_library):
  The link interface of target "las" contains:

    Boost::serialization

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /usr/lib64/cmake/libLAS/liblas-config.cmake:27 (include)
  CMake/vtkModule.cmake:4787 (find_package)
  IO/LAS/CMakeLists.txt:1 (vtk_module_find_package)
```
This makes the boost dependencies consistent.  I would think that there would be a better way to do this with cmake, but I don't know what that might be.