### PR TITLE
Fix build with GDAL 3.12

### DIFF
--- a/src/gt_citation.cpp
+++ b/src/gt_citation.cpp
@@ -34,7 +34,9 @@
 #include "geovalues.h"
 #include "gt_citation.h"
 
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,12,0)
 CPL_CVSID("$Id: gt_citation.cpp 21848 2011-02-25 16:41:38Z warmerdam $")
+#endif
 
 static const char *apszUnitMap[] = {
     "meters", "1.0",

--- a/src/gt_wkt_srs.cpp
+++ b/src/gt_wkt_srs.cpp
@@ -45,7 +45,9 @@
 #include "gt_wkt_srs_for_gdal.h"
 #include "gt_citation.h"
 
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,12,0)
 CPL_CVSID("$Id$")
+#endif
 
 #define ProjLinearUnitsInterpCorrectGeoKey   3059
 

--- a/src/gt_wkt_srs.cpp
+++ b/src/gt_wkt_srs.cpp
@@ -301,7 +301,9 @@ char *GTIFGetOGISDefn( GTIF *hGTIF, GTIFDefn * psDefn )
                 oSRS.SetFromUserInput(pszWKT);
                 oSRS.SetExtension( "PROJCS", "PROJ4",
                                    "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs" );
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,5,0)
                 oSRS.FixupOrdering();
+#endif
                 CPLFree(pszWKT);
                 pszWKT = NULL;
                 oSRS.exportToWkt(&pszWKT);
@@ -507,7 +509,9 @@ char *GTIFGetOGISDefn( GTIF *hGTIF, GTIFDefn * psDefn )
         {
             char	*pszWKT;
             oSRS.morphFromESRI();
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,5,0)
             oSRS.FixupOrdering();
+#endif
             if( oSRS.exportToWkt( &pszWKT ) == OGRERR_NONE )
                 return pszWKT;
         }
@@ -1109,7 +1113,9 @@ char *GTIFGetOGISDefn( GTIF *hGTIF, GTIFDefn * psDefn )
 /* ==================================================================== */
     char	*pszWKT;
 
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,5,0)
     oSRS.FixupOrdering();
+#endif
 
     if( oSRS.exportToWkt( &pszWKT ) == OGRERR_NONE )
         return pszWKT;


### PR DESCRIPTION
Some minor fixes to enable build with GDAL 3.12.

- Avoid use of CPL_CVSID with GDAL >=3.12
- Avoid use of OSRFixupOrdering with GDAL >=2.5

Closes #164