### PR TITLE
Fix build with GDAL 3.13: define MAX, MIN, ABS

### DIFF
--- a/src/gt_citation.h
+++ b/src/gt_citation.h
@@ -35,6 +35,16 @@
 #include "geo_normalize.h"
 #include "ogr_spatialref.h"
 
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef ABS
+#define ABS(x) (((x) < 0) ? (-1 * (x)) : (x))
+#endif
+
 char* ImagineCitationTranslation(char* psCitation, geokey_t keyID);
 char** CitationStringParse(char* psCitation, geokey_t keyID);
 


### PR DESCRIPTION
Before GDAL 3.13 these macros were defined by GDAL, but with 3.13 no more and cause build failure.

Code copied from https://github.com/OSGeo/gdal/blob/v3.12.4/port/cpl_port.h